### PR TITLE
Fix usage of millis() to avoid overflow

### DIFF
--- a/msrc/escHW3.cpp
+++ b/msrc/escHW3.cpp
@@ -32,7 +32,7 @@ void EscHW3::update()
             }
         }
     }
-    if ((uint16_t)millis() - tsEsc_ > 150)
+    if ((uint16_t)(millis() - tsEsc_) > 150)
     {
         pwm_ = 0;
         thr_ = 0;

--- a/msrc/ibus.cpp
+++ b/msrc/ibus.cpp
@@ -178,7 +178,7 @@ void Ibus::update()
     {
         static uint16_t ts = 0;
         uint8_t packetType = IBUS_RECEIVED_NONE;
-        if ((uint16_t)millis() - ts > 100)
+        if ((uint16_t)(millis() - ts) > 100)
         {
             packetType = IBUS_RECEIVED_POLL;
             address++;

--- a/msrc/smartport.cpp
+++ b/msrc/smartport.cpp
@@ -198,7 +198,7 @@ uint8_t Smartport::read(uint8_t &sensorId, uint8_t &frameId, uint16_t &dataId, u
         boolean header = false;
         uint8_t cont = 0;
         uint16_t tsRead = millis();
-        while ((uint16_t)millis() - tsRead < SMARTPORT_TIMEOUT)
+        while ((uint16_t)(millis() - tsRead) < SMARTPORT_TIMEOUT)
         {
             if (serial_.available())
             {


### PR DESCRIPTION
This PR fixes issues with causes an overflow of the casted millis() usage every ~64 seconds. This overflow will potentially create problems in some situations.