### PR TITLE
Fix task function signatures to match TaskFunction_t

### DIFF
--- a/board/project/led.c
+++ b/board/project/led.c
@@ -3,7 +3,7 @@
 #include "pico/stdlib.h"
 #include "ws2812.h"
 
-void led_task() {
+void led_task(void *params) {
     const uint WS2812_PIN = 16;
     gpio_init(PICO_DEFAULT_LED_PIN);
     gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);

--- a/board/project/led.h
+++ b/board/project/led.h
@@ -5,6 +5,6 @@
 
 extern context_t context;
 
-void led_task();
+void led_task(void *params);
 
 #endif

--- a/board/project/usb.c
+++ b/board/project/usb.c
@@ -17,7 +17,7 @@ static uint8_t buffer_rx[USB_BUFFER_LENGTH];
 static int read_usb();
 static void process_usb(int lenght);
 
-void usb_task() {
+void usb_task(void *params) {
     while (1) {
         int length = read_usb();
         if (length) process_usb(length);

--- a/board/project/usb.h
+++ b/board/project/usb.h
@@ -5,7 +5,7 @@
 
 extern context_t context;
 
-void usb_task();
+void usb_task(void *params);
 
 extern context_t context;
 


### PR DESCRIPTION
usb_task and led_task were declared as void f() (no parameters), but xTaskCreate expects TaskFunction_t which is void (*)(void *). On GCC 14+, -Wincompatible-pointer-types is promoted to an error by default, which breaks the build on modern toolchains such as Pico SDK 2.2.0 (ARM GCC 15.2).

Update both declarations and definitions to take a void *params argument (unused), matching the existing pattern of other task functions in the project.