### PR TITLE
Write full 16-bit INA3221 configuration register (was truncated to 8 …

### DIFF
--- a/board/project/sensor/ina3221.c
+++ b/board/project/sensor/ina3221.c
@@ -59,7 +59,7 @@ static void begin(ina3221_parameters_t *parameter) {
     gpio_pull_up(I2C0_SDA_GPIO);
     gpio_pull_up(I2C0_SCL_GPIO);
 
-    uint8_t data[2] = {0};
+    uint8_t data[3] = {0};
 
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     while (i2c_write_blocking_until(i2c0, parameter->i2c_address, data, 1, false, make_timeout_time_ms(1000)) ==
@@ -68,15 +68,22 @@ static void begin(ina3221_parameters_t *parameter) {
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
 
-    // Configure sensor
-    data[0] = INA3221_CONFIGURATION;
-    data[1] = MODE_VOLTAGE_CONTINUOUS | VOLTAGE_CONVERSION_TIME | (parameter->filter << 9);
+    // Configure sensor. INA3221 Configuration register is 16 bits wide: an I2C write
+    // therefore needs register address + 2 data bytes (MSB first). Build the full
+    // 16-bit value as uint16_t first, then split into high/low bytes — otherwise the
+    // upper byte (which holds the channel-enable bits 12-14 and the AVG bits 9-11)
+    // would be silently truncated by a single-byte store.
     if (parameter->cell_count > 3) parameter->cell_count = 3;
     if (parameter->cell_count < 1) parameter->cell_count = 1;
+    uint16_t config = MODE_VOLTAGE_CONTINUOUS | VOLTAGE_CONVERSION_TIME |
+                      ((uint16_t)parameter->filter << 9);
     for (uint8_t i = 1; i < parameter->cell_count; i++) {
-        data[1] |= (1 << (i + 12));
+        config |= (uint16_t)(1u << (i + 12));
     }
-    i2c_write_blocking(i2c0, parameter->i2c_address, data, 2, false);
+    data[0] = INA3221_CONFIGURATION;
+    data[1] = (uint8_t)(config >> 8);    // MSB: CH enables, AVG, conversion time MSBs
+    data[2] = (uint8_t)(config & 0xFF);  // LSB: conversion time LSBs, mode
+    i2c_write_blocking(i2c0, parameter->i2c_address, data, 3, false);
 }
 
 static void read(ina3221_parameters_t *parameter) {


### PR DESCRIPTION
…bits)

The INA3221 Configuration register (0x00) is 16 bits wide, so an I2C write needs `register address + 2 data bytes` (MSB first). The current code instead stores the desired configuration value into a single `uint8_t` (`data[1]`) and writes only one data byte, silently truncating the upper byte. The compiler flags this:

  ina3221.c:73: warning: overflow in conversion from 'int' to 'uint8_t'
  changes value from '(int)parameter->filter << 9 | 1360' to '80'
  [-Woverflow]

Concretely, for the default filter setting the intended 16-bit value is 0x0750 (MODE_VOLTAGE_CONTINUOUS | VOLTAGE_CONVERSION_TIME | filter<<9 | channel-enable bits), which truncates to 0x50 -- losing the AVG bits (9-11) and the channel-enable bits (12-14) entirely. The sensor falls back to its power-on defaults for those fields, which happen to enable all channels in continuous mode, so simple setups work by accident; the user-configured filter setting is ignored.

Fix: build the value as `uint16_t` first, then write register address plus high byte plus low byte (3 bytes total) so the full configuration reaches the chip.

Verified on Pico SDK 2.2.0 / ARM GCC 15.2 -- warning is gone and the filter setting now actually takes effect.