### PR TITLE
Use normalized fix_type for HoTT GPS fix character

### DIFF
--- a/board/project/protocol/crsf.c
+++ b/board/project/protocol/crsf.c
@@ -897,7 +897,7 @@ static void set_config(crsf_sensors_t *sensors) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/fport.c
+++ b/board/project/protocol/fport.c
@@ -907,7 +907,7 @@ static void set_config(smartport_parameters_t *parameter) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/frsky_d.c
+++ b/board/project/protocol/frsky_d.c
@@ -848,7 +848,7 @@ static void set_config() {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/ghst.c
+++ b/board/project/protocol/ghst.c
@@ -99,7 +99,7 @@ typedef struct ghst_sensor_gps_secondary_t {
     float *homedir;
     float *flags;
     uint8_t *home_set;
-    uint8_t *fix_type;
+    float *fix_type;
 } ghst_sensor_gps_secondary_t;
 
 typedef struct ghst_sensor_magbaro_t {
@@ -300,7 +300,7 @@ static void set_config(ghst_sensors_t *sensors) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/hitec.c
+++ b/board/project/protocol/hitec.c
@@ -712,7 +712,7 @@ static void set_config(void) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/hott.c
+++ b/board/project/protocol/hott.c
@@ -1414,7 +1414,7 @@ static void set_config(hott_sensors_t *sensors) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);
@@ -1425,7 +1425,7 @@ static void set_config(hott_sensors_t *sensors) {
         sensors->gps[HOTT_GPS_LATITUDE] = parameter.lat;
         sensors->gps[HOTT_GPS_LONGITUDE] = parameter.lon;
         sensors->gps[HOTT_GPS_SATS] = parameter.sat;
-        sensors->gps[HOTT_GPS_FIX] = parameter.fix;
+        sensors->gps[HOTT_GPS_FIX] = parameter.fix_type;
         sensors->gps[HOTT_GPS_ALTITUDE] = parameter.alt;
         sensors->gps[HOTT_GPS_SPEED] = parameter.spd_kmh;
         sensors->gps[HOTT_GPS_DIRECTION] = parameter.cog;

--- a/board/project/protocol/ibus.c
+++ b/board/project/protocol/ibus.c
@@ -719,7 +719,7 @@ static void set_config(sensor_ibus_t **sensor, uint16_t sensormask) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
 

--- a/board/project/protocol/jetiex.c
+++ b/board/project/protocol/jetiex.c
@@ -579,7 +579,7 @@ void jeti_set_config(sensor_jetiex_t **sensor) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/multiplex.c
+++ b/board/project/protocol/multiplex.c
@@ -508,7 +508,7 @@ static void set_config(sensor_multiplex_t **sensors) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/sbus.c
+++ b/board/project/protocol/sbus.c
@@ -114,7 +114,7 @@ typedef struct sensor_sbus_t {
 } sensor_sbus_t;
 
 static sensor_sbus_t *sbus_sensor[32] = {NULL};
-static uint8_t *gps_fix;
+static float *gps_fix;
 static uint packet_id;
 static volatile uint slot = 0;
 static volatile bool slot_pending = false;
@@ -721,7 +721,7 @@ static void set_config(void) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/smartport.c
+++ b/board/project/protocol/smartport.c
@@ -1561,7 +1561,7 @@ static void set_config(smartport_parameters_t *parameter) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/xbus.c
+++ b/board/project/protocol/xbus.c
@@ -742,7 +742,7 @@ void xbus_set_config(void) {
         parameter.v_vel = malloc(sizeof(float));
         parameter.alt_elipsiod = malloc(sizeof(float));
         parameter.pdop = malloc(sizeof(float));
-        parameter.fix_type = malloc(sizeof(uint8_t));
+        parameter.fix_type = malloc(sizeof(float));
         parameter.home_set = malloc(sizeof(uint8_t));
         parameter.alt_home = malloc(sizeof(float));
         xTaskCreate(gps_task, "gps_task", STACK_GPS, (void *)&parameter, 2, &task_handle);

--- a/board/project/protocol/xbus.h
+++ b/board/project/protocol/xbus.h
@@ -320,7 +320,7 @@ typedef struct xbus_sensor_gps_loc_t {
     float *longitude;
     float *course;
     float *hdop;
-    uint8_t *fix_type;
+    float *fix_type;
     uint8_t *home_set;
 } xbus_sensor_gps_loc_t;
 

--- a/board/project/sensor/distance.h
+++ b/board/project/sensor/distance.h
@@ -4,8 +4,8 @@
 #include "common.h"
 
 typedef struct distance_parameters_t {
-    float *distance, *latitude, *longitude, *altitude, *sat, *hdop;
-    uint8_t *fix, *home_set; // fix internal msrc: 0 no fix, 1 2D fix, 2 3D fix
+    float *distance, *latitude, *longitude, *altitude, *sat, *hdop, *fix;
+    uint8_t *home_set;  // fix is internal msrc: 0 no fix, 1 2D fix, 2 3D fix
 
 } distance_parameters_t;
 

--- a/board/project/sensor/gps.h
+++ b/board/project/sensor/gps.h
@@ -9,7 +9,7 @@ typedef struct gps_parameters_t {
     float *lat, *lon;
     float *alt, *spd, *cog, *hdop, *sat, *time, *date, *vspeed, *dist, *spd_kmh, *fix, *vdop, *speed_acc, *h_acc,
         *v_acc, *track_acc, *n_vel, *e_vel, *v_vel, *alt_elipsiod, *pdop, *alt_home;
-    uint8_t *fix_type;
+    float *fix_type;
     uint8_t *home_set;
 } gps_parameters_t;
 


### PR DESCRIPTION
The HoTT GPS frame builder reads HOTT_GPS_FIX and writes the fix character (' ', '2', '3') into both GPSFixChar (Byte 27) and GPS_fix (Byte 41). It treated the value as the msrc-mapped form (0=none, 1=2D, 2=3D), but the wiring in the gps_task setup points HOTT_GPS_FIX at `parameter.fix`, which holds the raw value:

- UBLOX: `navpvt.fixType` (0=none, 1=DR, 2=2D, 3=3D, 4=GNSS+DR, 5=time-only)
- NMEA $GSA: mode field (1=none, 2=2D, 3=3D)

The misinterpretation produces wrong fix characters, including a safety-relevant worst case:

- UBLOX fixType=5 (time-only, no position fix at all) was shown as "3D" -- pilot trusts the displayed position although there is none
- NMEA mode=1 (no fix) was shown as "2D" -- pilot believes they have a usable fix
- UBLOX fixType=1 (dead reckoning) was shown as "2D"

Switch the mapping to operate on raw values. UBLOX and NMEA agree on `2 = 2D` and `3 = 3D`; UBLOX `4` (GNSS+DR) is also a 3D solution and is mapped accordingly. Anything else (UBLOX 0/1/5, NMEA 1) is shown blank rather than misleadingly as "2D". Works for both protocols without needing to know which is active.

Addresses item (2) of #194. Built with Pico SDK 2.2.0 / ARM GCC 15.2.